### PR TITLE
Fix bug in strip_url with very unusual urls

### DIFF
--- a/ArmPackManager/__init__.py
+++ b/ArmPackManager/__init__.py
@@ -39,7 +39,7 @@ RootPackURL = "http://www.keil.com/pack/index.idx"
 
 protocol_matcher = compile("\w*://")
 def strip_protocol(url) :
-    return protocol_matcher.sub("", str(url))
+    return protocol_matcher.sub("", str(url), count=1)
 
 def largest_version(versions) :
     return sorted(versions, reverse=True, key=lambda v: LooseVersion(v))[0]

--- a/tests/unit.py
+++ b/tests/unit.py
@@ -36,6 +36,7 @@ def test_do_queue(queue):
 
 @given(text(alphabet=ascii_lowercase), text(alphabet=ascii_lowercase + ":/_."))
 @example("http", "google.com")
+@example("http", "google.com://foo")
 def test_strip_protocol(protocol, url):
     uri = protocol + "://" + url
     assert(ArmPackManager.strip_protocol(uri) == url)


### PR DESCRIPTION
A url of the format `"<word1>://<word2>://"` would be stripped to `""` when
the correct stripping would have it stripped to `<word2>://`. This
commit corrects that behavior.