### PR TITLE
Speedup appveyor builds

### DIFF
--- a/appveyor.bat
+++ b/appveyor.bat
@@ -50,7 +50,7 @@ rustc --version
 cargo --version
 
 cd rust
-cargo test %CARGO_MODE%
+cargo test --release
 if %ERRORLEVEL% NEQ 0 exit 1
 cd ..
 


### PR DESCRIPTION
Before this commit, appveyor would test with debug and then
create the wheel with release. This commit changes the tests
to use release. I'm hoping that'll de-duplicate some compiling.