### PR TITLE
Rework CFFI to force Python to handle printing

### DIFF
--- a/cmsis_pack_manager/__init__.py
+++ b/cmsis_pack_manager/__init__.py
@@ -198,11 +198,14 @@ class Cache (object):
                     )
                 if (
                     total_downloads and not self.silent
-                    and current_downloads > prev_downloads
+                    and current_downloads != prev_downloads
                 ):
-                    sys.stdout.write("({}/{})\r".format(
-                        current_downloads, total_downloads
-                    ))
+                    sys.stdout.write(
+                        "Downloading PDSC files({:03}/{:03})\r".format(
+                            current_downloads, total_downloads
+                        )
+                    )
+                    sys.stdout.flush()
             pdsc_index = lib.update_pdsc_result(poll_obj)
         return pdsc_index
 

--- a/rust/cmsis-cffi/src/pack.rs
+++ b/rust/cmsis-cffi/src/pack.rs
@@ -28,7 +28,8 @@ cffi!{
             };
             let conf = conf_bld.build()?;
             with_from_raw!(let packs = parsed_packs, {
-                install(&conf, packs.iter(), &log).map(|_| ())
+                /* TODO: () used here to drop all messagses. THIS IS VERY BAD */
+                install(&conf, packs.iter(), &log, ()).map(|_| ())
             })
         } else {
             Err(err_msg("update packs received a Null pointer"))

--- a/rust/cmsis-cli/Cargo.toml
+++ b/rust/cmsis-cli/Cargo.toml
@@ -9,6 +9,7 @@ failure = "0.1.1"
 slog = "^2"
 slog-async = "^2"
 slog-term = "^2"
+pbr = "^1.0.0"
 
 [dependencies.cmsis-update]
 path = "../cmsis-update"

--- a/rust/cmsis-update/Cargo.toml
+++ b/rust/cmsis-update/Cargo.toml
@@ -14,7 +14,6 @@ slog-term = "^2"
 slog-async = "^2"
 tokio-core = "0.1.17"
 failure = "0.1.1"
-pbr = "^1.0.0"
 
 utils = { path = "../utils" }
 pack-index = { path = "../pack-index" }

--- a/rust/cmsis-update/src/download.rs
+++ b/rust/cmsis-update/src/download.rs
@@ -9,7 +9,6 @@ use futures::prelude::{await, async_block, async_stream_block, stream_yield, Fut
 use hyper::{Body, Client, Uri};
 use hyper::client::Connect;
 use slog::Logger;
-use pbr::ProgressBar;
 use std::sync::Arc;
 
 use pack_index::config::Config;
@@ -34,25 +33,6 @@ impl DownloadProgress for () {
     fn complete(&self) {}
     fn for_file(&self, _: &str) -> Self {
         ()
-    }
-}
-
-impl<'a, W: Write + Send + 'a> DownloadProgress for &'a Mutex<ProgressBar<W>> {
-    fn size(&self, files: usize) {
-        if let Ok(mut inner) = self.lock() {
-            inner.total = files as u64;
-            inner.show_speed = false;
-            inner.show_bar = true;
-        }
-    }
-    fn progress(&self, _: usize) {}
-    fn complete(&self) {
-        if let Ok(mut inner) = self.lock() {
-            inner.inc();
-        }
-    }
-    fn for_file(&self, _: &str) -> Self {
-        self.clone()
     }
 }
 

--- a/rust/cmsis-update/src/download.rs
+++ b/rust/cmsis-update/src/download.rs
@@ -21,7 +21,7 @@ pub(crate) trait IntoDownload {
     fn into_fd(&self, &Config) -> PathBuf;
 }
 
-pub trait DownloadProgress: Sync {
+pub trait DownloadProgress: Send {
     fn size(&self, files: usize);
     fn progress(&self, bytes: usize);
     fn complete(&self);

--- a/rust/cmsis-update/src/lib.rs
+++ b/rust/cmsis-update/src/lib.rs
@@ -38,7 +38,7 @@ mod dl_pack;
 
 use dl_pdsc::{update_future};
 use dl_pack::{install_future};
-use download::DownloadProgress;
+pub use download::DownloadProgress;
 
 // This will "trick" the borrow checker into thinking that the lifetimes for
 // client and core are at least as big as the lifetime for pdscs, which they actually are


### PR DESCRIPTION
Which allows the `silent` parameter to mean something.

Coming soon: error printing from the python too