### PR TITLE
Log Errors when downloading vidx tree

### DIFF
--- a/rust/cmsis-update/src/dl_pdsc.rs
+++ b/rust/cmsis-update/src/dl_pdsc.rs
@@ -46,10 +46,7 @@ pub fn update_future<'a, C, I, P>(
 {
     let parsed_vidx = download_vidx_list(vidx_list, client, logger);
     let pdsc_list = parsed_vidx
-        .filter_map(move |vidx| match vidx {
-            Ok(v) => Some(flatmap_pdscs(v, client, logger)),
-            Err(_) => None,
-        })
+        .filter_map(move |vidx| vidx.map(|v| flatmap_pdscs(v, client, logger)))
         .flatten();
     download_stream(config, pdsc_list, client, logger, progress).collect()
 }

--- a/rust/cmsis-update/src/redirect.rs
+++ b/rust/cmsis-update/src/redirect.rs
@@ -25,6 +25,7 @@ impl<C: Connect> ClientRedirExt<C> for Client<C, Body> {
             let mut urls = Vec::new();
             loop {
                 urls.push(uri.clone());
+                debug!(logger, "Starting GET of {}", uri);
                 let res = await!(self.get(uri))?;
                 match res.status() {
                     StatusCode::MovedPermanently |


### PR DESCRIPTION
Some time yesterday, an entry was updated to include a URL that does not
resolve to a host. This causes `pack-manager cache pdsc` to stop hard in
it's tracks and refuses to continue past the point at which it stoped.

This PR makes the downloads optional (instead of a result that can fail).
Now `pack-manager cache pdsc` will simply log this an an error including
the url in the message.

Resolves #88 