### PR TITLE
Use index.pidx by default

### DIFF
--- a/rust/pack-index/src/config.rs
+++ b/rust/pack-index/src/config.rs
@@ -89,8 +89,7 @@ impl Config {
             Err(_) => {
                 warn!(l, "Failed to open vendor index list read only. Recreating.");
                 let new_content = vec![
-                    String::from("http://www.keil.com/pack/keil.vidx"),
-                    String::from("http://www.keil.com/pack/keil.pidx"),
+                    String::from("http://www.keil.com/pack/index.pidx"),
                 ];
                 match self.vidx_list.parent() {
                     Some(par) => {


### PR DESCRIPTION
Acording to the CMSIS Team, The `index.pidx` file is created from
the index of `Keil.vidx` and `Keil.pidx` nighly. Using the `index.pidx`
index should result in fewer requests to remote servers, and will
be more stable as well.