### PR TITLE
Stop depending on futures-async-await

### DIFF
--- a/rust/cmsis-update/Cargo.toml
+++ b/rust/cmsis-update/Cargo.toml
@@ -5,8 +5,6 @@ authors = ["Jimmy Brisson <theotherjimmy@gmail.com>"]
 
 [dependencies]
 futures = "=0.1.25"
-futures-await = "0.1.1"
-futures-await-async-macro = "0.1.4"
 hyper = "0.11.21"
 hyper-rustls = "0.12.0"
 minidom = "0.5.0"

--- a/rust/cmsis-update/src/lib.rs
+++ b/rust/cmsis-update/src/lib.rs
@@ -1,6 +1,6 @@
 #![feature(generators, libc, proc_macro_hygiene)]
 
-extern crate futures_await as futures;
+extern crate futures;
 extern crate tokio_core;
 extern crate hyper;
 extern crate hyper_rustls;


### PR DESCRIPTION
This is one step closer to building with a stable version,
and reduces the total number of dependencies to 182