### PR TITLE
Enable sdist through manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include *.txt
+recursive-include rust *.toml *.rs *.h
+prune rust/target
+prune rust/*/target


### PR DESCRIPTION
This should allow the next version to be published as an sdist with the 
`python setup.py sdist` command. I have tested that this generates a 
working install of CPM locally and will backport this to 0.2.8.