### PR TITLE
Switch to native TLS stack (work-around for #121)

### DIFF
--- a/build-wheels.sh
+++ b/build-wheels.sh
@@ -41,7 +41,7 @@ else
     rm -rf /io/dist/* || echo "No old wheels to delete"
 
     # Install libraries needed for compiling the extension
-    yum -q -y install libffi-devel
+    yum -q -y install libffi-devel openssl-devel 
 
     # Compile wheel
     ${PYBIN}/python -m pip wheel /io/ -w /dist/

--- a/rust/cmsis-pack/Cargo.toml
+++ b/rust/cmsis-pack/Cargo.toml
@@ -17,7 +17,7 @@ futures = "0.1.29"
 log = "0.4.8"
 minidom = "^0.12.0"
 quick-xml = "0.17.2"
-reqwest = { version = "0.9.24", default_features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.9.24", default_features = false, features = ["default-tls", "trust-dns"] }
 rustc-demangle = "0.1.16"
 serde = "^1.0.89"
 serde_derive = "^1.0.89"

--- a/rust/cmsis-pack/src/update/download.rs
+++ b/rust/cmsis-pack/src/update/download.rs
@@ -130,7 +130,7 @@ where
 {
     pub fn new(config: &'a Conf, prog: Prog) -> Result<Self, Error> {
         let client = ClientBuilder::new()
-            .use_rustls_tls()
+            .use_default_tls()
             .use_sys_proxy()
             .redirect(RedirectPolicy::limited(5))
             .build()?;


### PR DESCRIPTION
The `rustls-tls` option is "too secure" for the configuration of the TLS servers currently serving packs. I suggest we try temporarily downgrading to `default-tls` until the situation improves.