### PR TITLE
Make types necessary for probe-rs public

### DIFF
--- a/rust/cmsis-pack/src/pdsc/device.rs
+++ b/rust/cmsis-pack/src/pdsc/device.rs
@@ -247,10 +247,10 @@ pub struct MemoryPermissions {
     pub read: bool,
     pub write: bool,
     pub execute: bool,
-    peripheral: bool,
-    secure: bool,
-    non_secure: bool,
-    non_secure_callable: bool,
+    pub peripheral: bool,
+    pub secure: bool,
+    pub non_secure: bool,
+    pub non_secure_callable: bool,
 }
 
 impl MemoryPermissions {

--- a/rust/cmsis-pack/src/pdsc/device.rs
+++ b/rust/cmsis-pack/src/pdsc/device.rs
@@ -8,7 +8,7 @@ use minidom::Element;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-enum Core {
+pub enum Core {
     CortexM0,
     CortexM0Plus,
     CortexM1,
@@ -121,7 +121,7 @@ impl FromStr for MPU {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Processor {
     units: u8,
-    core: Core,
+    pub core: Core,
     fpu: FPU,
     mpu: MPU,
 }
@@ -243,10 +243,10 @@ impl FromElem for ProcessorsBuilder {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct MemoryPermissions {
-    read: bool,
-    write: bool,
-    execute: bool,
+pub struct MemoryPermissions {
+    pub read: bool,
+    pub write: bool,
+    pub execute: bool,
     peripheral: bool,
     secure: bool,
     non_secure: bool,
@@ -311,12 +311,12 @@ impl FromStr for NumberBool {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct Memory {
-    access: MemoryPermissions,
-    start: u64,
-    size: u64,
-    startup: bool,
-    default: bool,
+pub struct Memory {
+    pub access: MemoryPermissions,
+    pub start: u64,
+    pub size: u64,
+    pub startup: bool,
+    pub default: bool,
 }
 
 struct MemElem(String, Memory);
@@ -360,7 +360,7 @@ impl FromElem for MemElem {
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Memories(HashMap<String, Memory>);
+pub struct Memories(pub HashMap<String, Memory>);
 
 fn merge_memories(lhs: Memories, rhs: &Memories) -> Memories {
     let rhs: Vec<_> = rhs

--- a/rust/cmsis-pack/src/pdsc/mod.rs
+++ b/rust/cmsis-pack/src/pdsc/mod.rs
@@ -15,7 +15,7 @@ mod device;
 
 pub use crate::pdsc::component::{ComponentBuilders, FileRef};
 pub use crate::pdsc::condition::{Condition, Conditions};
-pub use crate::pdsc::device::{Algorithm, Device, Devices, Memories, Processors};
+pub use crate::pdsc::device::{Algorithm, Core, Device, Devices, Memories, Processors};
 
 pub struct Release {
     pub version: String,


### PR DESCRIPTION
In [probe-rs](https://github.com/probe-rs/) we currently use a fork of cmsis-pack-manager, but would prefer to go back to using this repository. The only difference right now is that we need access to some data which is currently private. This PR makes all of them public.

