### PR TITLE
setup.cfg: bump pyyaml version; other dependency cleanup.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,15 +35,10 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    appdirs>=1.4
-    milksnake>=0.1.2
-    pyyaml>=5.1
+    appdirs>=1.4,<2.0
+    milksnake>=0.1.5,<1.0
+    pyyaml>=6.0,<7.0
 python_requires = >=3.6
-tests_require =
-    hypothesis
-    jinja2
-    mock
-    pytest
 include_package_data = True
 zip_safe = False
 


### PR DESCRIPTION
- Bump pyyaml to the new version 6.0, and set max version < 7.0.
- Set max versions for other dependencies.
- Remove tests_require that is no longer needed.