### PR TITLE
Add download timeouts for PDSC entries

### DIFF
--- a/rust/cmsis-pack/src/update/download.rs
+++ b/rust/cmsis-pack/src/update/download.rs
@@ -19,6 +19,8 @@ use std::collections::HashMap;
 const CONCURRENCY: usize = 32;
 const HOST_LIMIT: usize = 6;
 const MAX_RETRIES: usize = 3;
+const CONNECT_TIMEOUT: u64 = 15;
+const TIMEOUT: u64 = 60;
 
 fn pdsc_url(pdsc: &mut PdscRef) -> String {
     if pdsc.url.ends_with('/') {
@@ -171,6 +173,8 @@ where
     pub fn new(config: &'a Conf, prog: Prog) -> Result<Self, Error> {
         let client = ClientBuilder::new()
             .redirect(redirect::Policy::limited(5))
+            .connect_timeout(Duration::from_secs(CONNECT_TIMEOUT))
+            .timeout(Duration::from_secs(TIMEOUT))
             .build()?;
 
         Ok(DownloadContext {

--- a/rust/cmsis-pack/src/update/download.rs
+++ b/rust/cmsis-pack/src/update/download.rs
@@ -20,7 +20,7 @@ const CONCURRENCY: usize = 32;
 const HOST_LIMIT: usize = 6;
 const MAX_RETRIES: usize = 3;
 const CONNECT_TIMEOUT: u64 = 15;
-const TIMEOUT: u64 = 60;
+const READ_TIMEOUT: u64 = 15;
 
 fn pdsc_url(pdsc: &mut PdscRef) -> String {
     if pdsc.url.ends_with('/') {
@@ -174,7 +174,7 @@ where
         let client = ClientBuilder::new()
             .redirect(redirect::Policy::limited(5))
             .connect_timeout(Duration::from_secs(CONNECT_TIMEOUT))
-            .timeout(Duration::from_secs(TIMEOUT))
+            .read_timeout(Duration::from_secs(READ_TIMEOUT))
             .build()?;
 
         Ok(DownloadContext {


### PR DESCRIPTION
Add a timeout of 5 seconds on downloads of PDSC entries, and log an error to stdout. This way broken PDSC entries do not hang the `pyocd pack update` command


Without this change:

```
$ pyocd pack clean
$ pyocd pack update
0000154 I Updating pack index... [pack_cmd]
Downloading descriptors (1611/1631) # command hangs here, does not complete
```

With this change:
```
$ pyocd pack clean
$ pyocd pack update
0000154 I Updating pack index... [pack_cmd]
17:44:58 [ERROR] Download of https://www.nsing.com.sg/uploadfile/file/pack/NSING.N32G05x_DFP.pdsc failed: Response code in invalid range: 500
17:44:58 [ERROR] Download of https://www.nsing.com.sg/uploadfile/file/pack/NSING.N32G030_DFP.pdsc failed: Response code in invalid range: 500
17:45:01 [ERROR] Download of http://www.ixys.com/Zilog/packs/Zilog.ZNEO32_DFP.pdsc failed: Response code in invalid range: 404
17:45:03 [ERROR] Download of https://www.abov.co.kr/data/mds/PACK/ABOV.A33G53x_Series.pdsc failed: error sending request for url (https://www.abov.co.kr/data/mds/PACK/ABOV.A33G53x_Series.pdsc)
17:45:03 [ERROR] Download of http://www.mcu.com.cn/Cmsemicon.BAT32G135-A.pdsc failed: Response code in invalid range: 404
17:45:03 [ERROR] Download of https://www.geehy.com/uploads/tool/Geehy.G32R5xx_DFP.pdsc failed: error sending request for url (https://www.geehy.com/uploads/tool/Geehy.G32R5xx_DFP.pdsc)
17:45:04 [ERROR] Download of http://www.qorvo.com/extra/keil_pack/Active-Semi.PAC52XX.pdsc failed: Response code in invalid range: 403
17:45:04 [ERROR] Download of http://www.qorvo.com/extra/keil_pack/Active-Semi.PAC55XX.pdsc failed: Response code in invalid range: 403
17:45:05 [ERROR] Download of http://download.analog.com/tools/EZBoards/ADSP-SC83x/Releases/AnalogDevices.ADSP-SC83x_FreeRTOS-OSAL.pdsc failed: error sending request for url (http://download.analog.com/tools/EZBoards/ADSP-SC83x/Releases/AnalogDevices.ADSP-SC83x_FreeRTOS-OSAL.pdsc)
17:45:06 [ERROR] Download of https://www.geehy.com/uploads/tool/Geehy.APM32F4xx_DFP.pdsc failed: error sending request for url (https://www.geehy.com/uploads/tool/Geehy.APM32F4xx_DFP.pdsc)
17:45:06 [ERROR] Download of https://www.geehy.com/uploads/tool/Geehy.APM32E1xx_DFP.pdsc failed: error sending request for url (https://www.geehy.com/uploads/tool/Geehy.APM32E1xx_DFP.pdsc)
17:45:06 [ERROR] Download of https://www.geehy.com/uploads/tool/Geehy.APM32F1xx_DFP.pdsc failed: error sending request for url (https://www.geehy.com/uploads/tool/Geehy.APM32F1xx_DFP.pdsc)
17:45:06 [ERROR] Download of https://www.geehy.com/uploads/tool/Geehy.APM32F0xx_DFP.pdsc failed: error sending request for url (https://www.geehy.com/uploads/tool/Geehy.APM32F0xx_DFP.pdsc)
17:45:06 [ERROR] Download of https://www.geehy.com/uploads/tool/Geehy.APM32F00x_DFP.pdsc failed: error sending request for url (https://www.geehy.com/uploads/tool/Geehy.APM32F00x_DFP.pdsc)
17:45:06 [ERROR] Download of https://ftp.willert.de/downloads/Keil/Pack/RXF/SodiusWillert.RXF.pdsc failed: Response code in invalid range: 404
17:45:07 [ERROR] Download of http://download.analog.com/tools/EZBoards/COG_4050/Releases/AnalogDevices.EV-COG-AD4050LZ_BSP.pdsc failed: error sending request for url (http://download.analog.com/tools/EZBoards/COG_4050/Releases/AnalogDevices.EV-COG-AD4050LZ_BSP.pdsc)
17:45:07 [ERROR] Download of http://download.analog.com/tools/EZBoards/COG_AD3029/Releases/AnalogDevices.EV-COG-AD3029LZ_BSP.pdsc failed: error sending request for url (https://download.analog.com/tools/EZBoards/COG_AD3029/Releases/AnalogDevices.EV-COG-AD3029LZ_BSP.pdsc)
17:45:07 [ERROR] Download of http://download.analog.com/tools/EZBoards/CM302x/Releases/AnalogDevices.ADuCM302x_DFP.pdsc failed: error sending request for url (http://download.analog.com/tools/EZBoards/CM302x/Releases/AnalogDevices.ADuCM302x_DFP.pdsc)
17:45:08 [ERROR] Download of https://www.geehy.com/uploads/tool/Geehy.APM32A4xx_DFP.pdsc failed: error sending request for url (https://www.geehy.com/uploads/tool/Geehy.APM32A4xx_DFP.pdsc)
17:45:09 [ERROR] Download of http://www.advsolned.com/armpack/ASN.Filter_Designer.pdsc failed: Response code in invalid range: 403
17:45:10 [ERROR] Download of https://geehy.com/uploads/tool/APEXMIC.APM32F1xx_DFP.pdsc failed: error sending request for url (https://geehy.com/uploads/tool/APEXMIC.APM32F1xx_DFP.pdsc)
17:45:11 [ERROR] Download of https://www.geehy.com/uploads/tool/Geehy.APM32S1xx_DFP.pdsc failed: error sending request for url (https://www.geehy.com/uploads/tool/Geehy.APM32S1xx_DFP.pdsc)
17:45:11 [ERROR] Download of https://www.geehy.com/uploads/tool/Geehy.APM32A0xx_DFP.pdsc failed: error sending request for url (https://www.geehy.com/uploads/tool/Geehy.APM32A0xx_DFP.pdsc)
17:45:11 [ERROR] Download of https://www.geehy.com/uploads/tool/Geehy.APM32A10x_DFP.pdsc failed: error sending request for url (https://www.geehy.com/uploads/tool/Geehy.APM32A10x_DFP.pdsc)
17:45:11 [ERROR] Download of https://www.geehy.com/uploads/tool/Geehy.APM32F035_DFP.pdsc failed: error sending request for url (https://www.geehy.com/uploads/tool/Geehy.APM32F035_DFP.pdsc)
Downloading descriptors (1631/1631)
```

Command completes and I can use the packs that downloaded correctly